### PR TITLE
Datatypes and pattern matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "durin"
 version = "0.1.0"
-source = "git+https://github.com/tolziplohu/durin?rev=51a4100db0990afd46fad25b3a0135e4f511ad62#51a4100db0990afd46fad25b3a0135e4f511ad62"
+source = "git+https://github.com/tolziplohu/durin?rev=215bcdebd1b4dfb868db15ff48f0a3081c1b13c6#215bcdebd1b4dfb868db15ff48f0a3081c1b13c6"
 dependencies = [
  "either",
  "inkwell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "durin"
 version = "0.1.0"
-source = "git+https://github.com/tolziplohu/durin?rev=0e07cab8b0eb583f530b12929d65da343d189e96#0e07cab8b0eb583f530b12929d65da343d189e96"
+source = "git+https://github.com/tolziplohu/durin?rev=51a4100db0990afd46fad25b3a0135e4f511ad62#51a4100db0990afd46fad25b3a0135e4f511ad62"
 dependencies = [
  "either",
  "inkwell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "durin"
 version = "0.1.0"
-source = "git+https://github.com/tolziplohu/durin?rev=215bcdebd1b4dfb868db15ff48f0a3081c1b13c6#215bcdebd1b4dfb868db15ff48f0a3081c1b13c6"
+source = "git+https://github.com/tolziplohu/durin?rev=71f584925a97d216473baf4861ce2d1e96cd1692#71f584925a97d216473baf4861ce2d1e96cd1692"
 dependencies = [
  "either",
  "inkwell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 name = "durin"
 version = "0.1.0"
-source = "git+https://github.com/tolziplohu/durin?rev=19bc5e2c9a8bf7f9dae4de892fdd3361a991c092#19bc5e2c9a8bf7f9dae4de892fdd3361a991c092"
+source = "git+https://github.com/tolziplohu/durin?rev=0e07cab8b0eb583f530b12929d65da343d189e96#0e07cab8b0eb583f530b12929d65da343d189e96"
 dependencies = [
  "either",
  "inkwell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ salsa = "*"
 codespan-reporting = "*"
 lazy_static = "*"
 pretty = { version = "*", features = ["termcolor"] }
-durin = { git = "https://github.com/tolziplohu/durin", rev = "215bcdebd1b4dfb868db15ff48f0a3081c1b13c6" }
+durin = { git = "https://github.com/tolziplohu/durin", rev = "71f584925a97d216473baf4861ce2d1e96cd1692" }
 smallvec = "*"
 assert_cmd = "*"
 predicates = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ salsa = "*"
 codespan-reporting = "*"
 lazy_static = "*"
 pretty = { version = "*", features = ["termcolor"] }
-durin = { git = "https://github.com/tolziplohu/durin", rev = "0e07cab8b0eb583f530b12929d65da343d189e96" }
+durin = { git = "https://github.com/tolziplohu/durin", rev = "51a4100db0990afd46fad25b3a0135e4f511ad62" }
 smallvec = "*"
 assert_cmd = "*"
 predicates = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ salsa = "*"
 codespan-reporting = "*"
 lazy_static = "*"
 pretty = { version = "*", features = ["termcolor"] }
-durin = { git = "https://github.com/tolziplohu/durin", rev = "19bc5e2c9a8bf7f9dae4de892fdd3361a991c092" }
+durin = { git = "https://github.com/tolziplohu/durin", rev = "0e07cab8b0eb583f530b12929d65da343d189e96" }
 smallvec = "*"
 assert_cmd = "*"
 predicates = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ salsa = "*"
 codespan-reporting = "*"
 lazy_static = "*"
 pretty = { version = "*", features = ["termcolor"] }
-durin = { git = "https://github.com/tolziplohu/durin", rev = "51a4100db0990afd46fad25b3a0135e4f511ad62" }
+durin = { git = "https://github.com/tolziplohu/durin", rev = "215bcdebd1b4dfb868db15ff48f0a3081c1b13c6" }
 smallvec = "*"
 assert_cmd = "*"
 predicates = "*"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Pika is a small, dependently typed ML with algebraic effects and unboxed types.
 This is the rewritten version of the compiler, and the new typechecker is heavily inspired by [smalltt](https://github.com/AndrasKovacs/smalltt).
 
-Currently, Pika can compile dependently-typed lambda calculus to LLVM (through [Durin](https://github.com/tolziplohu/durin), an dependently typed optimizing intermediate language) and thus native code, but it doesn't have many features implemented yet.
+Currently, Pika can compile dependently-typed lambda calculus to LLVM (through [Durin](https://github.com/tolziplohu/durin), a dependently typed optimizing intermediate language) and thus native code, but it doesn't have many features implemented yet.
 
 ### Example
 Pika doesn't have many features implemented yet, but here are some that currently work.
@@ -26,10 +26,24 @@ val test2 = id [Type] Type
 # And you can use explicit lambdas instead of `fun`
 # Also, `_` introduces a hole filled by unification
 val id2 : [T] T -> _ = \x. x
+
+# Pika has datatypes and pattern matching as well
+type Option T of
+  Some T
+  None
+where
+  # This is in Option's "associated namespace", as are the constructors, like `impl` in Rust.
+  # Code outside of the associated namespace needs to qualify the constructors when matching, like `Option.None`
+  fun unwrap_or [T] (self : Option T) (default : T) = case self of
+    Some x => x
+    None => default
+  end
+end
+val _ = Option.unwrap_or (Option.Some Type) (Type -> Type)
 ```
 
 #### Why "Pika"?
-Lots of languages has animal mascots, so Pika's is the pika.
+Lots of languages have animal mascots, so Pika's is the pika.
 Pikas are little mammals that live on mountains, close relatives of rabbits.
 Pika the language is also small, but it isn't a close relative of any rabbits.
 Since it has dependent types, it has pi types, and "Pika" has "Pi" in it, so that's something else.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 pub use crate::error::*;
 pub use crate::pretty::*;
 pub use crate::query::*;
-pub use std::collections::VecDeque;
+pub use std::collections::{HashMap, HashSet, VecDeque};
 pub use std::sync::{Arc, RwLock};
 
 /// A helper trait for accepting either owned or borrowed data, and cloning when necessary

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -814,6 +814,9 @@ pub fn elaborate_def(db: &dyn Compiler, def: DefId) -> Result<ElabInfo, DefError
                     }),
             );
 
+            // Add the associated namespace, including constructors, to this term's children
+            mcxt.children.extend(scope.iter().map(|&(_, id)| id));
+
             let scope = db.intern_scope(Arc::new(scope));
 
             Ok((

--- a/src/elaborate.rs
+++ b/src/elaborate.rs
@@ -83,7 +83,7 @@ impl Term {
             }
             Term::Error => Ok(Term::Error),
             Term::Type => Ok(Term::Type),
-            Term::Case(mut x, cases) => {
+            Term::Case(mut x, mut ty, cases) => {
                 let cases = cases
                     .into_iter()
                     .map(|(pat, body)| {
@@ -102,8 +102,9 @@ impl Term {
                         ))
                     })
                     .collect::<Result<_, _>>()?;
-                *x = x.check_solution(meta, ren, lfrom, lto, names)?;
-                Ok(Term::Case(x, cases))
+                *x = x.check_solution(meta.clone(), ren, lfrom, lto, names)?;
+                *ty = ty.check_solution(meta, ren, lfrom, lto, names)?;
+                Ok(Term::Case(x, ty, cases))
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,6 +154,10 @@ pub trait ToError {
 
 impl Eq for Error {}
 impl Error {
+    pub fn message(&mut self) -> &mut String {
+        &mut self.0.message
+    }
+
     pub fn no_label(message: impl Into<String>) -> Self {
         Error(Diagnostic::error().with_message(message))
     }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -45,7 +45,7 @@ impl Term {
                 let x = x.evaluate(env, mcxt, db);
                 f.app(icit, x, mcxt, db)
             }
-            Term::Case(x, cases) => {
+            Term::Case(x, _, cases) => {
                 let x = x.evaluate(env, mcxt, db);
                 for (pat, body) in cases {
                     if let Some(env) = pat.match_with(&x, env.clone(), mcxt, db) {
@@ -300,13 +300,14 @@ impl Term {
                     .inline_metas(mcxt, db)
                     .quote(l, mcxt, db)
             }
-            Term::Case(mut x, cases) => {
+            Term::Case(mut x, mut ty, cases) => {
                 *x = x.inline_metas(mcxt, l, db);
+                *ty = ty.inline_metas(mcxt, l, db);
                 let cases = cases
                     .into_iter()
                     .map(|(p, x)| (p.inline_metas(mcxt, db), x.inline_metas(mcxt, l, db)))
                     .collect();
-                Term::Case(x, cases)
+                Term::Case(x, ty, cases)
             }
             Term::Error => Term::Error,
         }

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -7,6 +7,7 @@ impl Term {
         match self {
             Term::Type => Val::Type,
             Term::Var(Var::Local(ix)) => env.val(ix),
+            Term::Var(Var::Type(id)) => Val::datatype(id),
             Term::Var(Var::Top(def)) => Val::top(def),
             Term::Var(Var::Rec(id)) => Val::rec(id),
             Term::Var(Var::Meta(meta)) => match mcxt.get_meta(meta) {
@@ -103,6 +104,7 @@ impl Val {
                     Var::Top(def) => Term::Var(Var::Top(def)),
                     Var::Meta(meta) => Term::Var(Var::Meta(meta)),
                     Var::Rec(id) => Term::Var(Var::Rec(id)),
+                    Var::Type(id) => Term::Var(Var::Type(id)),
                 };
                 sp.into_iter().fold(h, |f, (icit, x)| {
                     Term::App(icit, Box::new(f), Box::new(x.quote(enclosing, mcxt)))

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -235,63 +235,70 @@ RHS: Pre_ = {
 // Standard precedence for arithmetic operators
 Arith<S>: Pre_ = {
   Factor<S>,
-  Arith<S> "+" Factor<RHS> => todo!(),
-  Arith<S> "-" Factor<RHS> => todo!(),
+  Arith<S> "+" Factor<RHS> => todo!("+"),
+  Arith<S> "-" Factor<RHS> => todo!("-"),
 }
 Factor<S>: Pre_ = {
   Exp<S>,
-  Factor<S> "*" Exp<RHS> => todo!(),
-  Factor<S> "/" Exp<RHS> => todo!(),
+  Factor<S> "*" Exp<RHS> => todo!("*"),
+  Factor<S> "/" Exp<RHS> => todo!("/"),
 }
 Exp<S>: Pre_ = {
   S,
-  Exp<S> "**" RHS => todo!(),
+  Exp<S> "**" RHS => todo!("**"),
 }
 
 // No precedence for bitwise operators, but all are left-associative.
 Bitwise<S>: Pre_ = {
   // You can't use arithmetic with bitwise operators without parens, but we need a single chain.
   Arith<S>,
-  S ("&" RHS)+ => todo!(),
-  S ("|" RHS)+ => todo!(),
+  S ("&" RHS)+ => todo!("&"),
+  S ("|" RHS)+ => todo!("|"),
   // Single "^" is ambiguous: exponentiation or xor?
-  S ("^^" RHS)+ => todo!(),
+  S ("^^" RHS)+ => todo!("^^"),
   // I'd like << and >> for function composition, too - maybe the same operator, e.g. `impl [T P Q] ShiftRight (x: T -> P x) (y: [x] P x -> Q y) = ...`?
   // The alternative would be <<< and >>>.
-  S ("<<" RHS)+ => todo!(),
-  S (">>" RHS)+ => todo!(),
+  S ("<<" RHS)+ => todo!(">>"),
+  S (">>" RHS)+ => todo!("<<"),
 }
 
 // No precedence or associativity within comparison operators.
 // But, they're lower precedence than arithmetic or bitwise - `x + 2 == z * 3` works fine.
 Comparison<S>: Pre_ = {
   Bitwise<S>,
-  Bitwise<S> "==" Bitwise<RHS> => todo!(),
-  Bitwise<S> ">"  Bitwise<RHS> => todo!(),
-  Bitwise<S> "<"  Bitwise<RHS> => todo!(),
-  Bitwise<S> "<=" Bitwise<RHS> => todo!(),
-  Bitwise<S> ">=" Bitwise<RHS> => todo!(),
+  Bitwise<S> "==" Bitwise<RHS> => todo!("=="),
+  Bitwise<S> ">"  Bitwise<RHS> => todo!(">"),
+  Bitwise<S> "<"  Bitwise<RHS> => todo!("<"),
+  Bitwise<S> "<=" Bitwise<RHS> => todo!("<="),
+  Bitwise<S> ">=" Bitwise<RHS> => todo!(">="),
 }
 
 // No precedence between `and` and `or`, but one can be repeated: `x and y and z` works but not `x and y or z`.
 // These are lower precedence than Comparison, and are keywords since they don't actually behave like operators (lazy evaluation of the rhs).
 Logical<S>: Pre_ = {
   Comparison<S>,
-  Comparison<S> ("and" Comparison<RHS>)+ => todo!(),
-  Comparison<S> ("or"  Comparison<RHS>)+ => todo!(),
+  Comparison<S> ("and" Comparison<RHS>)+ => todo!("and"),
+  Comparison<S> ("or"  Comparison<RHS>)+ => todo!("or"),
 }
 
 // <| and |> have no precedence, but are left-associative: `x |> y |> z` = `z(y(x))`, `x <| y <| z` = `x y z`.
 Op: Pre_ = {
   Logical<LHS>,
-  LHS "<|" RHS => todo!(),
-  LHS "|>" RHS => todo!(),
+  LHS "<|" RHS => todo!("<|"),
+  LHS "|>" RHS => todo!("|>"),
   // `a . b c d` = `b c d a`, where `b` is looked up in the context of `a`'s type.
   // Unless `a.b` is a field, in which case it's `(a.b) c d`.
   // `a b . c d` isn't allowed.
   // `a b \n . c d` is, though, like other operators.
-  Atom "." Name AppArg* => todo!(),
-  Op OpNL "." Name AppArg* => todo!(),
+  <f:Sp<Atom>> "." <n:Sp<Name>> <v:Sp<AppArg>*> => {
+    let v = v.into_iter().map(|x| {
+      let span = x.span();
+      let (icit, pre) = x.unwrap();
+      (icit, Spanned::new(pre, span))
+    }).collect();
+    Pre_::Dot(f, n, v)
+  },
+  Op OpNL "." Name AppArg* => todo!("op dot"),
 }
 
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -76,6 +76,7 @@ extern {
   }
 }
 
+#[inline]
 Sp<T>: Spanned<T> = {
   <l:@L> <v:T> <r:@R> => Spanned::new(v, Span(l, r)),
 }
@@ -109,8 +110,8 @@ Def_: PreDef = {
     let ty = ty.unwrap_or_else(|| name.copy_span(Pre_::Hole(MetaSource::LocalType(*name))));
     PreDef::Val(name, ty, val)
   },
-  "type" "\n"* <name:Sp<Name>> <args:Args?> "of" <cons:Block<Cons>> => {
-    PreDef::Type(name, args.unwrap_or_else(Vec::new), cons)
+  "type" "\n"* <name:Sp<Name>> <args:Args?> "of" <cons:ConsBlock> => {
+    PreDef::Type(name, args.unwrap_or_else(Vec::new), cons.0, cons.1)
   },
   "impl" <name:("\n"* <Sp<Name>> ":")?> <ty:Sp<Term>> "=" <val:Sp<Term>> => {
     PreDef::Impl(name, ty, val)
@@ -298,7 +299,14 @@ Op: Pre_ = {
     }).collect();
     Pre_::Dot(f, n, v)
   },
-  Op OpNL "." Name AppArg* => todo!("op dot"),
+  <f:Sp<Op>> OpNL "." <n:Sp<Name>> <v:Sp<AppArg>*> => {
+    let v = v.into_iter().map(|x| {
+      let span = x.span();
+      let (icit, pre) = x.unwrap();
+      (icit, Spanned::new(pre, span))
+    }).collect();
+    Pre_::Dot(f, n, v)
+  },
 }
 
 
@@ -378,6 +386,22 @@ Block<T>: Vec<T> = {
   "\n"* <mut v:(<T> "\n"+)*> <last:T> "end" => {
     v.push(last);
     v
+  },
+}
+
+ConsBlock: (Vec<PreCons>, Vec<PreDefAn>) = {
+  "\n"* "end" => (Vec::new(), Vec::new()),
+  "\n"* <(<Cons> "\n"+)+> "end" => (<>, Vec::new()),
+  "\n"* <mut v:(<Cons> "\n"+)*> <last:Cons> "end" => {
+    v.push(last);
+    (v, Vec::new())
+  },
+
+  "\n"* "where" <Block<Def>> => (Vec::new(), <>),
+  "\n"* <(<Cons> "\n"+)+> "where" <Block<Def>>,
+  "\n"* <mut v:(<Cons> "\n"+)*> <last:Cons> "where" <v2:Block<Def>> => {
+    v.push(last);
+    (v, v2)
   },
 }
 

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -172,7 +172,7 @@ RStart: Pre_ = {
   "sig" Block<Def> => todo!("sigs"),
   "struct" <Block<Def>> => Pre_::Struct(<>),
   "do" <Block<Def>> => Pre_::Do(<>),
-  "case" Expr "of" Block<Branch> => todo!("case"),
+  "case" <x:Sp<Expr>> "of" <v:Block<Branch>> => Pre_::Case(x, v),
   // TODO: Is Expr okay here?
   // Basically we can't do multiline inside lambdas, we need
   // \x.(x
@@ -190,12 +190,20 @@ RStart: Pre_ = {
   },
 }
 
-Branch: () = {
-  Pat "=>" Term => (),
+Branch: (Pre, Pre) = {
+  <Sp<Pat>> "=>" <Sp<Term>>,
 }
-Pat: () = {
+Pat: Pre_ = {
   App,
-  App "|" Pat => (),
+  <f:Sp<Atom>> "." <n:Sp<Name>> <v:Sp<AppArg>*> => {
+    let v = v.into_iter().map(|x| {
+      let span = x.span();
+      let (icit, pre) = x.unwrap();
+      (icit, Spanned::new(pre, span))
+    }).collect();
+    Pre_::Dot(f, n, v)
+  },
+  <a:Sp<App>> "|" <b:Sp<Pat>> => Pre_::OrPat(a, b),
 }
 
 App: Pre_ = {

--- a/src/grammar.lalrpop
+++ b/src/grammar.lalrpop
@@ -101,18 +101,18 @@ Def_: PreDef = {
 
   "fun" "\n"* <name:Sp<Name>> <args:Args> <ty:(":" <Sp<Term>>)?> "=" <val:Sp<Term>> => {
     let ty = ty.unwrap_or_else(|| name.copy_span(Pre_::Hole(MetaSource::LocalType(*name))));
-    PreDef::Fun(name.unwrap(), args, ty, val)
+    PreDef::Fun(name, args, ty, val)
   },
   // You can have a function with an effect type but not a return type
   "fun" "\n"* Sp<Name> Args (":" App)? ("with" Term) "=" Term => todo!("effects"),
   "val" "\n"* <name:Sp<Name>> <ty:(":" <Sp<Term>>)?> "=" <val:Sp<Term>> => {
     let ty = ty.unwrap_or_else(|| name.copy_span(Pre_::Hole(MetaSource::LocalType(*name))));
-    PreDef::Val(name.unwrap(), ty, val)
+    PreDef::Val(name, ty, val)
   },
-  "type" "\n"* <name:Name> <args:Args> "of" <cons:Block<Cons>> => {
-    PreDef::Type(name, args, cons)
+  "type" "\n"* <name:Sp<Name>> <args:Args?> "of" <cons:Block<Cons>> => {
+    PreDef::Type(name, args.unwrap_or_else(Vec::new), cons)
   },
-  "impl" <name:("\n"* <Name> ":")?> <ty:Sp<Term>> "=" <val:Sp<Term>> => {
+  "impl" <name:("\n"* <Sp<Name>> ":")?> <ty:Sp<Term>> "=" <val:Sp<Term>> => {
     PreDef::Impl(name, ty, val)
   },
   Sp<Term> => PreDef::Expr(<>),
@@ -121,8 +121,8 @@ Def_: PreDef = {
 
   // TODO report an error if we use an arg without a type
   // although I guess elaboration will usually catch it
-  "fun" "\n"* <name:Sp<Name>> <args:Args> ":" <ty:Sp<Term>> => PreDef::FunDec(name.unwrap(), args, ty),
-  "val" "\n"* <name:Sp<Name>> ":" <ty:Sp<Term>> => PreDef::ValDec(name.unwrap(), ty),
+  "fun" "\n"* <name:Sp<Name>> <args:Args> ":" <ty:Sp<Term>> => PreDef::FunDec(name, args, ty),
+  "val" "\n"* <name:Sp<Name>> ":" <ty:Sp<Term>> => PreDef::ValDec(name, ty),
 };
 
 // Top-level expression groups
@@ -358,7 +358,8 @@ ConsArg: Vec<(Name, Icit, PreTy)> = {
 // Different language structures
 
 Cons: PreCons = {
-  <name:Name> <args:ConsArg*> <ty:(":" <Sp<Expr>>)?> => PreCons(name,
+  <name:Sp<Name>> <args:ConsArg*> <ty:(":" <Sp<Expr>>)?> => PreCons(
+    name,
     args.into_iter().flatten().collect(),
     ty,
   ),

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -106,7 +106,7 @@ impl Term {
                 }
                 Var::Rec(i) => *cxt.defs.get(i).unwrap(),
                 Var::Meta(_) => panic!("unsolved meta passed to lower()"),
-                Var::Type(_) => todo!("lowering datatypes"),
+                Var::Type(_, _) | Var::Cons(_) => todo!("lowering datatypes"),
             },
             // \x.f x
             // -->

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -80,7 +80,7 @@ impl<'db> LCxt<'db> {
 
 impl Val {
     pub fn lower(self, cxt: &mut LCxt) -> ir::Val {
-        self.quote(cxt.mcxt.size, &cxt.mcxt).lower(cxt)
+        self.quote(cxt.mcxt.size, &cxt.mcxt, cxt.db).lower(cxt)
     }
 }
 
@@ -114,8 +114,8 @@ impl Term {
             // fun k y = r y
             Term::Lam(name, _icit, _arg_ty, body) => {
                 let (param_ty, ret_ty) = match self.ty(&cxt.mcxt, cxt.db) {
-                    Val::Fun(from, to) => (*from, to.quote(cxt.mcxt.size, &cxt.mcxt)),
-                    Val::Pi(_, from, to) => (*from, to.quote(cxt.mcxt.size, &cxt.mcxt)),
+                    Val::Fun(from, to) => (*from, to.quote(cxt.mcxt.size, &cxt.mcxt, cxt.db)),
+                    Val::Pi(_, from, to) => (*from, to.quote(cxt.mcxt.size, &cxt.mcxt, cxt.db)),
                     _ => unreachable!(),
                 };
                 assert_eq!(cxt.mcxt.size, cxt.locals.size());
@@ -149,13 +149,16 @@ impl Term {
                 cxt.local(
                     *name,
                     pi.arg,
-                    (**from).clone().evaluate(&cxt.mcxt.env(), &cxt.mcxt),
+                    (**from)
+                        .clone()
+                        .evaluate(&cxt.mcxt.env(), &cxt.mcxt, cxt.db),
                 );
                 let to = to.lower(cxt);
                 cxt.pop_local();
                 cxt.builder.end_pi(pi, to)
             }
             Term::Error => panic!("type errors should have been caught by now!"),
+            Term::Case(_, _) => todo!("lowering case"),
         }
     }
 }

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -275,7 +275,7 @@ fn lower_datatype(
                                     env.push(Some(x.clone()));
                                     // If we solved it, skip adding it to the sigma
                                     // This shouldn't be used at all
-                                    cxt.builder.cons(ir::Constant::Stop)
+                                    cxt.builder.cons(ir::Constant::Unreachable)
                                 } else {
                                     // It doesn't have a solution, so it remains in the product type
                                     keep.push(true);

--- a/src/lower.rs
+++ b/src/lower.rs
@@ -106,6 +106,7 @@ impl Term {
                 }
                 Var::Rec(i) => *cxt.defs.get(i).unwrap(),
                 Var::Meta(_) => panic!("unsolved meta passed to lower()"),
+                Var::Type(_) => todo!("lowering datatypes"),
             },
             // \x.f x
             // -->

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ fn main() {
         db.check_all(id);
         if db.num_errors() == 0 {
             println!("File elaborated successfully!");
-        // let durin = db.durin(id);
-        // println!("Durin module:\n{}", durin.emit());
+            let durin = db.durin(id);
+            println!("Durin module:\n{}", durin.emit());
         } else {
             db.write_errors();
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod evaluate;
 pub mod lexer;
 pub mod lower;
+pub mod pattern;
 pub mod pretty;
 pub mod query;
 pub mod term;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ fn main() {
             println!("Durin module:\n{}", durin.emit());
             let backend = durin::backend::Backend::native();
             let m = backend.codegen_module(&mut durin);
-            println!("LLVM module:\n{}", m.print_to_string().to_str().unwrap());
+            m.verify().unwrap();
+        // println!("LLVM module:\n{}", m.print_to_string().to_str().unwrap());
         } else {
             db.write_errors();
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ fn main() {
             println!("Durin module:\n{}", durin.emit());
             let backend = durin::backend::Backend::native();
             let m = backend.codegen_module(&mut durin);
+            // println!("LLVM module:\n{}", m.print_to_string().to_str().unwrap());
             m.verify().unwrap();
-        // println!("LLVM module:\n{}", m.print_to_string().to_str().unwrap());
         } else {
             db.write_errors();
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,11 @@ fn main() {
         db.check_all(id);
         if db.num_errors() == 0 {
             println!("File elaborated successfully!");
-            let durin = db.durin(id);
+            let mut durin = db.durin(id);
             println!("Durin module:\n{}", durin.emit());
+            let backend = durin::backend::Backend::native();
+            let m = backend.codegen_module(&mut durin);
+            println!("LLVM module:\n{}", m.print_to_string().to_str().unwrap());
         } else {
             db.write_errors();
             std::process::exit(1);

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,0 +1,260 @@
+use crate::common::*;
+use crate::elaborate::*;
+use crate::term::*;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum Pat {
+    Any,
+    Var(Name, Box<VTy>),
+    Cons(DefId, Vec<Pat>),
+    Or(Box<Pat>, Box<Pat>),
+}
+impl Pat {
+    pub fn pretty(&self, db: &dyn Compiler, names: &mut Names) -> Doc {
+        match self {
+            Pat::Any => Doc::start("_"),
+            Pat::Var(n, _ty) => {
+                let n = names.disamb(*n, db);
+                names.add(n);
+                Doc::start(n.get(db))
+            }
+            Pat::Cons(id, p) => Doc::start(
+                db.lookup_intern_predef(db.lookup_intern_def(*id).0)
+                    .name()
+                    .unwrap()
+                    .get(db),
+            )
+            .chain(Doc::intersperse(
+                p.iter()
+                    .map(|x| Doc::none().space().chain(x.pretty(db, names))),
+                Doc::none(),
+            )),
+            Pat::Or(x, y) => x
+                .pretty(db, names)
+                .space()
+                .add('|')
+                .space()
+                .chain(y.pretty(db, names)),
+        }
+    }
+
+    pub fn add_locals(&self, mcxt: &mut MCxt, db: &dyn Compiler) {
+        match self {
+            Pat::Any => {}
+            Pat::Var(n, ty) => mcxt.define(*n, NameInfo::Local((**ty).clone()), db),
+            Pat::Cons(_, v) => {
+                for p in v {
+                    p.add_locals(mcxt, db);
+                }
+            }
+            Pat::Or(_, _) => {
+                // Right now we don't allow bindings in or-patterns
+                ()
+            }
+        }
+    }
+
+    pub fn add_names(&self, l: Lvl, names: &mut Names) -> Lvl {
+        match self {
+            Pat::Any => l,
+            Pat::Var(n, _) => {
+                names.add(*n);
+                l.inc()
+            }
+            Pat::Cons(_, v) => v.iter().fold(l, |l, p| p.add_names(l, names)),
+            Pat::Or(_, _) => l,
+        }
+    }
+
+    pub fn inline_metas(self, mcxt: &MCxt, db: &dyn Compiler) -> Self {
+        match self {
+            Pat::Any => Pat::Any,
+            Pat::Var(n, mut t) => {
+                *t = t.inline_metas(mcxt, db);
+                Pat::Var(n, t)
+            }
+            Pat::Cons(x, y) => {
+                Pat::Cons(x, y.into_iter().map(|x| x.inline_metas(mcxt, db)).collect())
+            }
+            Pat::Or(mut x, mut y) => {
+                *x = x.inline_metas(mcxt, db);
+                *y = y.inline_metas(mcxt, db);
+                Pat::Or(x, y)
+            }
+        }
+    }
+
+    pub fn match_with(
+        &self,
+        val: &Val,
+        mut env: Env,
+        mcxt: &MCxt,
+        db: &dyn Compiler,
+    ) -> Option<Env> {
+        match self {
+            Pat::Any => Some(env),
+            Pat::Var(_, _) => {
+                env.push(Some(val.clone()));
+                Some(env)
+            }
+            Pat::Cons(id, v) => match val.clone().inline(env.size, db, mcxt) {
+                Val::App(Var::Cons(id2), sp, _) => {
+                    if *id == id2 {
+                        for (i, (_, val)) in v.iter().zip(&sp) {
+                            env = i.match_with(val, env, mcxt, db)?;
+                        }
+                        Some(env)
+                    } else {
+                        None
+                    }
+                }
+                _ => unreachable!(),
+            },
+            Pat::Or(x, y) => x
+                .match_with(val, env.clone(), mcxt, db)
+                .or_else(|| y.match_with(val, env, mcxt, db)),
+        }
+    }
+}
+
+pub fn elab_case(
+    value: Term,
+    val_ty: VTy,
+    cases: &[(Pre, Pre)],
+    mut ret_ty: Option<VTy>,
+    mcxt: &mut MCxt,
+    db: &dyn Compiler,
+) -> Result<(Term, VTy), TypeError> {
+    let state = mcxt.state();
+    let mut rcases = Vec::new();
+    for (pat, body) in cases {
+        mcxt.set_state(state);
+        let pat = elab_pat(pat, &val_ty, mcxt, db)?;
+        let body = match &ret_ty {
+            Some(ty) => check(body, &ty, db, mcxt)?,
+            None => {
+                let (term, ty) = infer(true, body, db, mcxt)?;
+                ret_ty = Some(ty);
+                term
+            }
+        };
+        rcases.push((pat, body));
+    }
+    Ok((Term::Case(Box::new(value), rcases), ret_ty.unwrap()))
+}
+
+pub fn elab_pat(pre: &Pre, ty: &VTy, mcxt: &mut MCxt, db: &dyn Compiler) -> Result<Pat, TypeError> {
+    match &**pre {
+        Pre_::Var(n) => {
+            if let Some(NameResult::Def(id)) = mcxt.lookup(*n, db) {
+                if let Ok(info) = db.elaborate_def(id) {
+                    if let Term::Var(Var::Cons(id2)) = &*info.term {
+                        if id == *id2 {
+                            // This is a constructor
+                            return Ok(Pat::Cons(id, Vec::new()));
+                        }
+                    }
+                }
+            }
+            mcxt.define(*n, NameInfo::Local(ty.clone()), db);
+            Ok(Pat::Var(*n, Box::new(ty.clone())))
+        }
+        Pre_::Hole(MetaSource::Hole) => Ok(Pat::Any),
+        Pre_::App(_, _, _) => {
+            /// Find the head and spine of an application
+            fn sep(pre: &Pre) -> (&Pre, VecDeque<(Icit, &Pre)>) {
+                match &**pre {
+                    Pre_::App(i, f, x) => {
+                        let (head, mut spine) = sep(f);
+                        spine.push_back((*i, x));
+                        (head, spine)
+                    }
+                    _ => (pre, VecDeque::new()),
+                }
+            }
+            let (head, spine) = sep(pre);
+
+            elab_pat_app(head, spine, mcxt, db)
+        }
+        Pre_::Dot(head, member, spine) => elab_pat_app(
+            &pre.copy_span(Pre_::Dot(head.clone(), member.clone(), Vec::new())),
+            spine.iter().map(|(i, x)| (*i, x)).collect(),
+            mcxt,
+            db,
+        ),
+        Pre_::OrPat(x, y) => {
+            let size_before = mcxt.size;
+            let x = elab_pat(x, ty, mcxt, db)?;
+            if mcxt.size != size_before {
+                todo!("error: for now we don't support capturing inside or-patterns")
+            }
+            let y = elab_pat(y, ty, mcxt, db)?;
+            if mcxt.size != size_before {
+                todo!("error: for now we don't support capturing inside or-patterns")
+            }
+
+            Ok(Pat::Or(Box::new(x), Box::new(y)))
+        }
+        _ => Err(TypeError::InvalidPattern(pre.span())),
+    }
+}
+
+fn elab_pat_app(
+    head: &Pre,
+    mut spine: VecDeque<(Icit, &Pre)>,
+    mcxt: &mut MCxt,
+    db: &dyn Compiler,
+) -> Result<Pat, TypeError> {
+    let span = Span(
+        head.span().0,
+        spine.back().map(|(_, x)| x.span()).unwrap_or(head.span()).1,
+    );
+
+    let (term, mut ty) = infer(false, head, db, mcxt)?;
+    match term.inline_top(db) {
+        Term::Var(Var::Cons(id)) => {
+            let mut pspine = Vec::new();
+
+            let arity = ty.arity(true);
+            let f_arity = spine.iter().filter(|(i, _)| *i == Icit::Expl).count();
+
+            while let Some((i, pat)) = spine.pop_front() {
+                match ty {
+                    Val::Pi(Icit::Impl, from, cl) if i == Icit::Expl => {
+                        // Add an implicit argument to the pattern, and keep the explicit one on the stack
+                        spine.push_front((i, pat));
+                        mcxt.define(
+                            db.intern_name("_".into()),
+                            NameInfo::Local((*from).clone()),
+                            db,
+                        );
+                        pspine.push(Pat::Var(cl.2, from));
+                        ty = cl.vquote(mcxt.size, mcxt, db);
+                    }
+                    Val::Pi(i2, from, cl) if i == i2 => {
+                        let pat = elab_pat(pat, &from, mcxt, db)?;
+                        pspine.push(pat);
+                        ty = cl.vquote(mcxt.size, mcxt, db);
+                    }
+                    Val::Fun(from, to) if i == Icit::Expl => {
+                        let pat = elab_pat(pat, &from, mcxt, db)?;
+                        pspine.push(pat);
+                        ty = *to;
+                    }
+                    _ => return Err(TypeError::WrongNumConsArgs(span, arity, f_arity)),
+                }
+            }
+
+            match ty {
+                Val::Fun(_, _) | Val::Pi(_, _, _) => {
+                    return Err(TypeError::WrongNumConsArgs(span, arity, f_arity))
+                }
+                // TODO unify with expected type for GADTs
+                _ => (),
+            }
+
+            Ok(Pat::Cons(id, pspine))
+        }
+        _ => Err(TypeError::InvalidPattern(span)),
+    }
+}

--- a/src/query.rs
+++ b/src/query.rs
@@ -185,6 +185,7 @@ pub struct ElabInfo {
     pub term: Arc<Term>,
     pub typ: Arc<VTy>,
     pub solved_globals: Arc<Vec<RecSolution>>,
+    pub children: Arc<Vec<DefId>>,
 }
 
 #[salsa::query_group(InternerDatabase)]

--- a/src/query.rs
+++ b/src/query.rs
@@ -99,7 +99,7 @@ impl Cxt {
                 }
                 NameInfo::Rec(id) => {
                     if name == sym {
-                        return Ok((Var::Rec(id), Val::meta(Meta::Type(id))));
+                        return Ok((Var::Rec(id), Val::meta(Meta::Type(id), Val::Type)));
                     }
                 }
                 NameInfo::Other(v, ty) => {

--- a/src/query.rs
+++ b/src/query.rs
@@ -47,7 +47,7 @@ This is needed for (mutually) recursive definitions, where context for one defin
 );
 intern_id!(
     ScopeId,
-    "A reference to a child scope attached to its parent, for a datatype's associated module or a structure."
+    "A reference to a scope with members, for a datatype's associated module or a structure."
 );
 intern_id!(
     Cxt,
@@ -96,6 +96,11 @@ impl Cxt {
                 NameInfo::Rec(id) => {
                     if name == sym {
                         return Some(NameResult::Rec(id));
+                    }
+                }
+                NameInfo::TypedRec(id, ty) => {
+                    if name == sym {
+                        return Some(NameResult::TypedRec(id, ty));
                     }
                 }
             }
@@ -152,6 +157,7 @@ pub enum NameResult {
     Def(DefId),
     Local(Ix, VTy),
     Rec(PreDefId),
+    TypedRec(PreDefId, VTy),
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
@@ -159,6 +165,7 @@ pub enum NameInfo {
     Def(DefId),
     Local(VTy),
     Rec(PreDefId),
+    TypedRec(PreDefId, VTy),
 }
 
 /// One cell of the context linked list.
@@ -262,7 +269,7 @@ pub fn intern_block(v: Vec<PreDefAn>, db: &dyn Compiler, mut cxt: Cxt) -> Vec<De
         match &*def {
             // Unordered
             PreDef::Fun(_, _, _, _)
-            | PreDef::Type(_, _, _)
+            | PreDef::Type(_, _, _, _)
             | PreDef::FunDec(_, _, _)
             | PreDef::ValDec(_, _) => {
                 let name = def.name();

--- a/src/query.rs
+++ b/src/query.rs
@@ -9,6 +9,12 @@ macro_rules! intern_id {
         #[doc=$doc]
         #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
         pub struct $name(salsa::InternId);
+        impl $name {
+            /// Returns the underlying number identifying the object, for debugging purposes
+            pub fn num(self) -> u32 {
+                self.0.as_u32()
+            }
+        }
         impl salsa::InternKey for $name {
             fn from_intern_id(id: salsa::InternId) -> Self {
                 Self(id)

--- a/src/query.rs
+++ b/src/query.rs
@@ -50,6 +50,10 @@ intern_id!(
     "A reference to a scope with members, for a datatype's associated module or a structure."
 );
 intern_id!(
+    TypeId,
+    "A reference to a datatype and its constructors, but not its associated module."
+);
+intern_id!(
     Cxt,
     r#"The context for resolving names, represented as a linked list of definitions, with the links stored in Salsa.
 This is slower than a hashmap or flat array, but it has better incrementality."#
@@ -73,7 +77,7 @@ impl Cxt {
         }
     }
 
-    pub fn lookup<T: ?Sized + Interner>(self, sym: Name, db: &T) -> Option<NameResult> {
+    pub fn lookup(self, sym: Name, db: &dyn Compiler) -> Result<(Var<Ix>, VTy), DefError> {
         let mut cxt = self;
         let mut ix = Ix::zero();
         while let MaybeEntry::Yes(CxtEntry {
@@ -83,30 +87,30 @@ impl Cxt {
             match info {
                 NameInfo::Def(id) => {
                     if name == sym {
-                        return Some(NameResult::Def(id));
+                        return Ok((Var::Top(id), (*db.def_type(id)?).clone()));
                     }
                 }
                 NameInfo::Local(ty) => {
                     if name == sym {
-                        return Some(NameResult::Local(ix, ty));
+                        return Ok((Var::Local(ix), ty));
                     } else {
                         ix = ix.inc()
                     }
                 }
                 NameInfo::Rec(id) => {
                     if name == sym {
-                        return Some(NameResult::Rec(id));
+                        return Ok((Var::Rec(id), Val::meta(Meta::Type(id))));
                     }
                 }
-                NameInfo::TypedRec(id, ty) => {
+                NameInfo::Other(v, ty) => {
                     if name == sym {
-                        return Some(NameResult::TypedRec(id, ty));
+                        return Ok((v, ty));
                     }
                 }
             }
             cxt = rest;
         }
-        None
+        Err(DefError::NoValue)
     }
 
     #[must_use]
@@ -152,20 +156,12 @@ impl RecSolution {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub enum NameResult {
-    Def(DefId),
-    Local(Ix, VTy),
-    Rec(PreDefId),
-    TypedRec(PreDefId, VTy),
-}
-
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub enum NameInfo {
     Def(DefId),
     Local(VTy),
     Rec(PreDefId),
-    TypedRec(PreDefId, VTy),
+    Other(Var<Ix>, VTy),
 }
 
 /// One cell of the context linked list.
@@ -205,6 +201,9 @@ pub trait Interner: salsa::Database {
     #[salsa::interned]
     fn intern_scope(&self, scope: Arc<Vec<(Name, DefId)>>) -> ScopeId;
 
+    #[salsa::interned]
+    fn intern_type(&self, constructors: Arc<Vec<(Name, DefId)>>) -> TypeId;
+
     /// The context is stored as a linked list, but the links are hashmap keys!
     /// This is... pretty slow, but has really good incrementality.
     #[salsa::interned]
@@ -221,9 +220,9 @@ pub trait CompilerExt: Interner {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum DefError {
-    /// This happens when we try to get the value of a definition that doesn't have one, like a declaration
+    /// This happens when we can't find a variable, or we try to get the value of a definition that doesn't have one, like a declaration.
     NoValue,
-    ElabError,
+    ElabError(DefId),
 }
 
 #[salsa::query_group(CompilerDatabase)]

--- a/src/term.rs
+++ b/src/term.rs
@@ -275,7 +275,8 @@ pub enum Term {
     Fun(Box<Ty>, Box<Ty>),
     /// Stores the type of `f`
     App(Icit, Box<Term>, Box<Ty>, Box<Term>),
-    Case(Box<Term>, Vec<(Pat, Term)>),
+    /// Stores the type of the scrutinee as the second argument
+    Case(Box<Term>, Box<Ty>, Vec<(Pat, Term)>),
     /// There was a type error somewhere, and we already reported it, so we want to continue as much as we can.
     Error,
 }
@@ -467,7 +468,7 @@ impl Term {
                 })
                 .prec(Prec::App),
             Term::Error => Doc::start("<error>"),
-            Term::Case(x, cases) => Doc::keyword("case")
+            Term::Case(x, _, cases) => Doc::keyword("case")
                 .space()
                 .chain(x.pretty(db, names))
                 .space()

--- a/src/term.rs
+++ b/src/term.rs
@@ -740,8 +740,7 @@ impl Glued {
             match h {
                 // Check the mcxt's local constraints
                 Var::Local(lvl) => {
-                    let term = mcxt.local_val(lvl)?;
-                    let val = term.clone().evaluate(&Env::new(l), mcxt, db);
+                    let val = mcxt.local_val(lvl)?.clone();
                     let val = sp
                         .into_owned()
                         .into_iter()

--- a/src/term.rs
+++ b/src/term.rs
@@ -95,7 +95,7 @@ pub struct PreCons(pub SName, pub Vec<(Name, Icit, PreTy)>, pub Option<PreTy>);
 pub enum PreDef {
     Fun(SName, Vec<(Name, Icit, PreTy)>, PreTy, Pre),
     Val(SName, PreTy, Pre),
-    Type(SName, Vec<(Name, Icit, PreTy)>, Vec<PreCons>),
+    Type(SName, Vec<(Name, Icit, PreTy)>, Vec<PreCons>, Vec<PreDefAn>),
     Impl(Option<SName>, PreTy, Pre),
     Expr(Pre),
 
@@ -111,7 +111,7 @@ impl PreDef {
         match self {
             PreDef::Fun(n, _, _, _)
             | PreDef::Val(n, _, _)
-            | PreDef::Type(n, _, _)
+            | PreDef::Type(n, _, _, _)
             | PreDef::FunDec(n, _, _)
             | PreDef::Cons(n, _)
             | PreDef::ValDec(n, _) => Some(**n),
@@ -125,7 +125,7 @@ impl PreDef {
         match self {
             PreDef::Fun(n, _, _, _) => n.span(),
             PreDef::Val(n, _, _) => n.span(),
-            PreDef::Type(n, _, _) => n.span(),
+            PreDef::Type(n, _, _, _) => n.span(),
             PreDef::Impl(Some(n), _, _) => n.span(),
             PreDef::Impl(None, _, t) => t.span(),
             PreDef::Expr(t) => t.span(),

--- a/src/term.rs
+++ b/src/term.rs
@@ -281,7 +281,12 @@ impl Term {
                 Var::Top(i) | Var::Type(i, _) | Var::Cons(i) => {
                     (*db.elaborate_def(i).unwrap().typ).clone()
                 }
-                Var::Rec(_) => todo!("find meta solution"),
+                Var::Rec(i) => mcxt.get_meta(Meta::Type(i)).unwrap_or_else(|| {
+                    panic!(
+                        "No type found for Rec {}",
+                        db.lookup_intern_predef(i).name().unwrap().get(db)
+                    )
+                }),
                 Var::Meta(_) => todo!("find meta solution"),
             },
             Term::Lam(n, i, ty, body) => {

--- a/src/term.rs
+++ b/src/term.rs
@@ -618,6 +618,9 @@ impl<T: PartialEq> Var<T> {
         match (self, other) {
             (x, y) if x == y => true,
 
+            // Ignore the scope id's, just make sure they're the same datatype
+            (Var::Type(a, _), Var::Type(b, _)) => a == b,
+
             (Var::Rec(a), Var::Type(b, _))
             | (Var::Type(b, _), Var::Rec(a))
             | (Var::Rec(a), Var::Top(b))

--- a/src/term.rs
+++ b/src/term.rs
@@ -300,19 +300,11 @@ impl Term {
                     )),
                 )
             }
-            Term::App(_, f, x) => match f.ty(mcxt, db) {
+            Term::App(_, f, x) => match f.ty(mcxt, db).inline(mcxt.size, db, mcxt) {
                 Val::Fun(_, to) => *to,
                 Val::Pi(_, _, cl) => {
                     cl.apply((**x).clone().evaluate(&mcxt.env(), mcxt, db), mcxt, db)
                 }
-                // It might be a name that refers to a function type, so we need to inline it
-                Val::App(h, sp, g) => match g.resolve(h, sp, mcxt.size, db, mcxt) {
-                    Some(Val::Fun(_, to)) => *to,
-                    Some(Val::Pi(_, _, cl)) => {
-                        cl.apply((**x).clone().evaluate(&mcxt.env(), mcxt, db), mcxt, db)
-                    }
-                    _ => unreachable!(),
-                },
                 _ => unreachable!(),
             },
             Term::Error => Val::Error,

--- a/tests/basic.pk
+++ b/tests/basic.pk
@@ -1,5 +1,10 @@
 # This is about everything that works so far!
 
+val AType = Type -> Type
+val M : Type -> AType = \x y.x
+val Z : M Type Type = Type
+val Q = Z
+
 val U : Type = Type
 
 fun the (x: Type) (y: x) : x = y

--- a/tests/basic.pk
+++ b/tests/basic.pk
@@ -30,7 +30,7 @@ x
 .
 x
 
-val local = do
+fun local (_:Type) = do
   fun f x = the Type x
   val t = Type -> Type
   f t

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -1,22 +1,29 @@
-type Term a of
-  # Type stated
-  TypeType : Term Type
-  # Normal ADT
-  Lit a
-  # Mixed before and after colon
-  Fun [a b] : Term (a -> b) -> Term (a -> b)
-where
-  # The constructors work without a dot here
-  fun also_lit [a] (x : a) : Term a = Lit x
+type Bool (a:Type) of
+  True Type               : Bool Type
+  False ((x: Type) -> x)  : Bool Type
 end
 
-val one : Term Type = Term.TypeType
-val two : Term (Term Type -> Term Type) = Term.Fun (Term.Lit (\x. x))
-# Make sure the associated namespace works
-val three : Term Type = Term.also_lit Type
+fun f x = Bool.True x
 
-# I'm not sure whether we actually want to allow this, but it works?
-fun pick_type (x : Type) : (Type -> Type) = Term
-val four : Term Type =
-  pick_type Type
-    .Lit Type
+# type Term a of
+#   # Type stated
+#   TypeType : Term Type
+#   # Normal ADT
+#   Lit a
+#   # Mixed before and after colon
+#   Fun [a b] : Term (a -> b) -> Term (a -> b)
+# where
+#   # The constructors work without a dot here
+#   fun also_lit [a] (x : a) : Term a = Lit x
+# end
+#
+# val one : Term Type = Term.TypeType
+# val two : Term (Term Type -> Term Type) = Term.Fun (Term.Lit (\x. x))
+# # Make sure the associated namespace works
+# val three : Term Type = Term.also_lit Type
+#
+# # I'm not sure whether we actually want to allow this, but it works?
+# fun pick_type (x : Type) : (Type -> Type) = Term
+# val four : Term Type =
+#   pick_type Type
+#     .Lit Type

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -4,8 +4,19 @@ type Term a of
   # Normal ADT
   Lit a
   # Mixed before and after colon
-  Fun [a] [b] : Term (a -> b) -> Term (a -> b)
+  Fun [a b] : Term (a -> b) -> Term (a -> b)
+where
+  # The constructors work without a dot here
+  fun also_lit [a] (x : a) : Term a = Lit x
 end
 
 val one : Term Type = Term.TypeType
 val two : Term (Term Type -> Term Type) = Term.Fun (Term.Lit (\x. x))
+# Make sure the associated namespace works
+val three : Term Type = Term.also_lit Type
+
+# I'm not sure whether we actually want to allow this, but it works?
+fun pick_type (x : Type) : (Type -> Type) = Term
+val four : Term Type =
+  pick_type Type
+    .Lit Type

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -1,9 +1,10 @@
-type Bool (a:Type) of
-  True Type               : Bool Type
-  False ((x: Type) -> x)  : Bool Type
+type Option a of
+  Some a
+  None
 end
 
-fun f x = Bool.True x
+fun make_some [t] (x : t) = Option.Some x
+fun make_none [t] : Option t = Option.None
 
 # type Term a of
 #   # Type stated

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -1,30 +1,22 @@
-type Option a of
-  Some a
-  None
+type Term a of
+  # Type stated
+  TypeType : Term Type
+  # Normal ADT
+  Lit a
+  # Mixed before and after colon
+  Fun [a b] : (a -> b) -> Term (a -> b)
+where
+  # The constructors work without a dot here
+  fun also_lit [a] (x : a) : Term a = Lit x
 end
 
-fun make_some [t] (x : t) = Option.Some x
-fun make_none [t] : Option t = Option.None
+val one : Term Type = Term.TypeType
+val two : Term (Type -> Type) = Term.Fun (\x. x)
+# Make sure the associated namespace works
+val three : Term Type = Term.also_lit Type
 
-# type Term a of
-#   # Type stated
-#   TypeType : Term Type
-#   # Normal ADT
-#   Lit a
-#   # Mixed before and after colon
-#   Fun [a b] : Term (a -> b) -> Term (a -> b)
-# where
-#   # The constructors work without a dot here
-#   fun also_lit [a] (x : a) : Term a = Lit x
-# end
-#
-# val one : Term Type = Term.TypeType
-# val two : Term (Term Type -> Term Type) = Term.Fun (Term.Lit (\x. x))
-# # Make sure the associated namespace works
-# val three : Term Type = Term.also_lit Type
-#
-# # I'm not sure whether we actually want to allow this, but it works?
-# fun pick_type (x : Type) : (Type -> Type) = Term
-# val four : Term Type =
-#   pick_type Type
-#     .Lit Type
+# I'm not sure whether we actually want to allow this, but it works?
+fun pick_type (x : Type) : (Type -> Type) = Term
+val four : Term Type =
+  pick_type Type
+    .Lit Type

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -1,0 +1,11 @@
+type Term a of
+  # Type stated
+  TypeType : Term Type
+  # Normal ADT
+  Lit a
+  # Mixed before and after colon
+  Fun [a] [b] : Term (a -> b) -> Term (a -> b)
+end
+
+# val one : Test = Test.One
+# val two : Test = Test.Two Test

--- a/tests/data.pk
+++ b/tests/data.pk
@@ -7,5 +7,5 @@ type Term a of
   Fun [a] [b] : Term (a -> b) -> Term (a -> b)
 end
 
-# val one : Test = Test.One
-# val two : Test = Test.Two Test
+val one : Term Type = Term.TypeType
+val two : Term (Term Type -> Term Type) = Term.Fun (Term.Lit (\x. x))

--- a/tests/duplicate_constructor.pk
+++ b/tests/duplicate_constructor.pk
@@ -1,0 +1,5 @@
+type Test of
+  Something
+  # duplicate
+  Something Type
+end

--- a/tests/gadt.pk
+++ b/tests/gadt.pk
@@ -19,6 +19,6 @@ end
 
 # And finally, here it needs to figure out that the other argument has type Type in one branch
 fun h [a] (x: GADT a) (y: a) : Type = case x of
-  GADT.Two t => (t -> t)
+  GADT.Two t => (y -> t)
   GADT.One => Type
 end

--- a/tests/gadt.pk
+++ b/tests/gadt.pk
@@ -12,13 +12,13 @@ fun f (x: GADT Type) = case x of
 end
 
 # Here it needs to figure out that in one branch a is Unit, and in the other it's Type
-fun g [a] (x: GADT a) = case x of
-  GADT.One _ => Unit.New
+fun g [a] (x: GADT a) : a = case x of
+  GADT.One => Unit.New
   GADT.Two t => t
 end
 
 # And finally, here it needs to figure out that the other argument has type Type in one branch
 fun h [a] (x: GADT a) (y: a) : Type = case x of
   GADT.Two t => (t -> t)
-  GADT.One _ => Type
+  GADT.One => Type
 end

--- a/tests/gadt.pk
+++ b/tests/gadt.pk
@@ -1,0 +1,24 @@
+type Unit of New end
+
+# This is a very simple GADT, but is actually a GADT and not just an ADT
+type GADT t of
+  One : GADT Unit
+  Two : Type -> GADT Type
+end
+
+# Here Pika needs to figure out that GADT.One is impossible for GADT Type, so this is exhaustive
+fun f (x: GADT Type) = case x of
+  GADT.Two t => t
+end
+
+# Here it needs to figure out that in one branch a is Unit, and in the other it's Type
+fun g [a] (x: GADT a) = case x of
+  GADT.One _ => Unit.New
+  GADT.Two t => t
+end
+
+# And finally, here it needs to figure out that the other argument has type Type in one branch
+fun h [a] (x: GADT a) (y: a) : Type = case x of
+  GADT.Two t => (t -> t)
+  GADT.One _ => Type
+end

--- a/tests/inexhaustive.pk
+++ b/tests/inexhaustive.pk
@@ -1,0 +1,9 @@
+type Bool of
+  True
+  False
+where
+  fun wrong (b: Bool) = case b of
+    True => False
+    True => True
+  end
+end

--- a/tests/match.pk
+++ b/tests/match.pk
@@ -1,0 +1,16 @@
+type Bool of
+  True
+  False
+where
+  fun not (b: Bool) = case b of
+    True => False
+    False => True
+  end
+end
+
+type Test of
+  Thing Type Type
+end
+fun test (t: Test) = case t of
+  Test.Thing a b => a -> b
+end

--- a/tests/match.pk
+++ b/tests/match.pk
@@ -14,3 +14,15 @@ end
 fun test (t: Test) = case t of
   Test.Thing a b => a -> b
 end
+
+type Option a of
+  None
+  Some a
+where
+  fun unwrap_or [a] (self : Option a) (default : a) : a = case self of
+    None => default
+    Some x => x
+  end
+end
+
+fun my_fun (x : Option Type) = Option.unwrap_or x (Type -> Type)

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -1,5 +1,6 @@
 use assert_cmd::*;
 use predicates::prelude::*;
+use predicates::str::*;
 
 #[test]
 fn test_basic() {
@@ -17,6 +18,35 @@ fn test_smalltt() {
         .args(&["tests/smalltt.pk"])
         .assert()
         .success();
+}
+
+#[test]
+fn test_data() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/data.pk"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_duplicate_constructor() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/duplicate_constructor.pk"])
+        .assert()
+        .stderr(contains("Duplicate"))
+        .failure();
+}
+
+#[test]
+fn test_wrong_constructor_type() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/wrong_constructor_type.pk"])
+        .assert()
+        .stderr(contains("Constructor return type"))
+        .failure();
 }
 
 #[test]

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -39,6 +39,15 @@ fn test_match() {
 }
 
 #[test]
+fn test_gadt() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/gadt.pk"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_inexhaustive() {
     Command::cargo_bin("pika")
         .unwrap()

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -11,14 +11,16 @@ fn test_basic() {
         .success();
 }
 
-#[test]
-fn test_smalltt() {
-    Command::cargo_bin("pika")
-        .unwrap()
-        .args(&["tests/smalltt.pk"])
-        .assert()
-        .success();
-}
+// Currently, this test takes over a minute to run on debug builds, so it's disabled.
+// It's still worth running `cargo run tests/smalltt.pk` before committing anything, though, to make sure it's not broken.
+// #[test]
+// fn test_smalltt() {
+//     Command::cargo_bin("pika")
+//         .unwrap()
+//         .args(&["tests/smalltt.pk"])
+//         .assert()
+//         .success();
+// }
 
 #[test]
 fn test_data() {

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -30,6 +30,15 @@ fn test_data() {
 }
 
 #[test]
+fn test_match() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/match.pk"])
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_duplicate_constructor() {
     Command::cargo_bin("pika")
         .unwrap()

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -39,6 +39,27 @@ fn test_match() {
 }
 
 #[test]
+fn test_inexhaustive() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/inexhaustive.pk"])
+        .assert()
+        .stderr(contains("Inexhaustive"))
+        .stderr(contains("'False' not covered"))
+        .failure();
+}
+
+#[test]
+fn test_wrong_cons() {
+    Command::cargo_bin("pika")
+        .unwrap()
+        .args(&["tests/wrong_cons.pk"])
+        .assert()
+        .stderr(contains("Invalid"))
+        .failure();
+}
+
+#[test]
 fn test_duplicate_constructor() {
     Command::cargo_bin("pika")
         .unwrap()

--- a/tests/wrong_cons.pk
+++ b/tests/wrong_cons.pk
@@ -1,0 +1,12 @@
+type One of
+  A
+end
+type Two of
+  B
+end
+
+fun f (x : One) = case x of
+  One.A => One.A
+  # This is the wrong type!
+  Two.B => One.A
+end

--- a/tests/wrong_constructor_type.pk
+++ b/tests/wrong_constructor_type.pk
@@ -1,0 +1,4 @@
+type Test of
+  # wrong return type
+  Wrong : Type
+end


### PR DESCRIPTION
Datatypes and pattern matching work pretty well now, so I'm going to merge them into the main `rewrite` branch. Recursive datatypes aren't supported yet, and won't be for a while, but GADTs work.